### PR TITLE
Update to use node16 runner

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: 'Comma-separated pairs PLACEHOLDER=value'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
- The node12 runner has been deprecated (see [GitHub blog post](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)). This action when used, emits an annotation, warning about this deprecation.
![image](https://user-images.githubusercontent.com/17473202/199205531-9708c084-f030-4852-9084-a021cba04809.png)
